### PR TITLE
Improve performance of nearest_time method

### DIFF
--- a/gym_mtsim/simulator/mt_simulator.py
+++ b/gym_mtsim/simulator/mt_simulator.py
@@ -100,9 +100,9 @@ class MtSimulator:
         if time in df.index:
             return time
         try:
-            i = df.index.get_loc(time, method='ffill')
+            i, = df.index.get_indexer([time], method='ffill')
         except KeyError:
-            i = df.index.get_loc(time, method='bfill')
+            i, = df.index.get_indexer([time], method='bfill')
         return df.index[i]
 
 


### PR DESCRIPTION
df.index.get_indexer is almost 10 times faster than df.index.get_loc